### PR TITLE
Support Python3

### DIFF
--- a/bin/fetch-gn
+++ b/bin/fetch-gn
@@ -10,7 +10,7 @@ import os
 import shutil
 import stat
 import sys
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 os.chdir(os.path.join(os.path.dirname(__file__), os.pardir))
 
@@ -29,7 +29,7 @@ def sha1_of_file(path):
 
 if sha1_of_file(dst) != sha1:
   with open(dst, 'wb') as f:
-    f.write(urllib2.urlopen('https://chromium-gn.storage-download.googleapis.com/' + sha1).read())
+    f.write(urllib.request.urlopen('https://chromium-gn.storage-download.googleapis.com/' + sha1).read())
 
   os.chmod(dst, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
                 stat.S_IRGRP                | stat.S_IXGRP |

--- a/gn/highest_version_dir.py
+++ b/gn/highest_version_dir.py
@@ -12,4 +12,4 @@ import sys
 dirpath = sys.argv[1]
 regex = re.compile(sys.argv[2])
 
-print sorted(filter(regex.match, os.listdir(dirpath)))[-1]
+print(sorted(filter(regex.match, os.listdir(dirpath)))[-1])

--- a/gn/toolchain/num_cpus.py
+++ b/gn/toolchain/num_cpus.py
@@ -7,4 +7,4 @@
 
 import multiprocessing
 
-print multiprocessing.cpu_count()
+print(multiprocessing.cpu_count())

--- a/infra/bots/gen_tasks_logic/gen_tasks_logic.go
+++ b/infra/bots/gen_tasks_logic/gen_tasks_logic.go
@@ -1470,7 +1470,7 @@ func (b *builder) presubmit(name string) string {
 	task.CipdPackages = append(task.CipdPackages, &specs.CipdPackage{
 		Name:    "infra/recipe_bundles/chromium.googlesource.com/chromium/tools/build",
 		Path:    "recipe_bundle",
-		Version: "refs/heads/master",
+		Version: "git_revision:617e0fd3186eaae8bcb7521def0d6d3b4a5bcaf1",
 	})
 	task.Dependencies = []string{} // No bundled recipes for this one.
 	b.MustAddTask(name, task)

--- a/infra/bots/tasks.json
+++ b/infra/bots/tasks.json
@@ -13821,7 +13821,7 @@
         {
           "name": "infra/recipe_bundles/chromium.googlesource.com/chromium/tools/build",
           "path": "recipe_bundle",
-          "version": "refs/heads/master"
+          "version": "git_revision:617e0fd3186eaae8bcb7521def0d6d3b4a5bcaf1"
         }
       ],
       "command": [

--- a/src/gpu/GrSurfaceProxy.h
+++ b/src/gpu/GrSurfaceProxy.h
@@ -102,8 +102,8 @@ public:
     bool isLazy() const { return !this->isInstantiated() && SkToBool(fLazyInstantiateCallback); }
 
     bool isFullyLazy() const {
-        bool result = fHeight <= 0;
-        SkASSERT(result == (fWidth <= 0));
+        bool result = fHeight < 0;
+        SkASSERT(result == (fWidth < 0));
         SkASSERT(!result || this->isLazy());
         return result;
     }

--- a/src/pdf/SkPDFSubsetFont.cpp
+++ b/src/pdf/SkPDFSubsetFont.cpp
@@ -72,7 +72,9 @@ static sk_sp<SkData> subset_harfbuzz(sk_sp<SkData> fontData,
     glyphUsage.getSetValues([&glyphs](unsigned gid) { hb_set_add(glyphs, gid);});
 
     hb_subset_input_set_retain_gids(input.get(), true);
-    hb_subset_input_set_drop_hints(input.get(), true);
+    // TODO: When possible, check if a font is 'tricky' with FT_IS_TRICKY.
+    // If it isn't known if a font is 'tricky', retain the hints.
+    hb_subset_input_set_drop_hints(input.get(), false);
     HBFace subset(hb_subset(face.get(), input.get()));
     HBBlob result(hb_face_reference_blob(subset.get()));
     return to_data(std::move(result));

--- a/tests/ProxyTest.cpp
+++ b/tests/ProxyTest.cpp
@@ -83,6 +83,17 @@ static void check_texture(skiatest::Reporter* reporter,
     GrSurfaceProxy::UniqueID idBefore = texProxy->uniqueID();
 
     bool preinstantiated = texProxy->isInstantiated();
+    // The instantiated texture should have these dimensions. If the fit is kExact, then
+    // 'worst-case' reports the original WxH. If it is kApprox, make sure that the texture
+    // is that size and didn't reuse one of the kExact surfaces in the provider. This is important
+    // because upstream usage (e.g. SkImage) reports size based on the worst case dimensions and
+    // client code may rely on that if they are creating backend resources.
+    // NOTE: we store these before instantiating, since after instantiation worstCaseWH() just
+    // return the target's dimensions. In this instance, we want to ensure the target's dimensions
+    // are no different from the original approximate (or exact) dimensions.
+    int expectedWidth = texProxy->worstCaseWidth();
+    int expectedHeight = texProxy->worstCaseHeight();
+
     REPORTER_ASSERT(reporter, texProxy->instantiate(provider));
     GrTexture* tex = texProxy->peekTexture();
 
@@ -94,13 +105,9 @@ static void check_texture(skiatest::Reporter* reporter,
         REPORTER_ASSERT(reporter, texProxy->uniqueID().asUInt() != tex->uniqueID().asUInt());
     }
 
-    if (SkBackingFit::kExact == fit) {
-        REPORTER_ASSERT(reporter, tex->width() == texProxy->width());
-        REPORTER_ASSERT(reporter, tex->height() == texProxy->height());
-    } else {
-        REPORTER_ASSERT(reporter, tex->width() >= texProxy->width());
-        REPORTER_ASSERT(reporter, tex->height() >= texProxy->height());
-    }
+    REPORTER_ASSERT(reporter, tex->width() == expectedWidth);
+    REPORTER_ASSERT(reporter, tex->height() == expectedHeight);
+
     REPORTER_ASSERT(reporter, tex->config() == texProxy->config());
 }
 

--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -167,7 +167,7 @@ def git_checkout_to_directory(git, repo, checkoutable, directory, verbose):
 
 def parse_file_to_dict(path):
   dictionary = {}
-  execfile(path, dictionary)
+  exec(compile(open(path, "rb").read(), path, 'exec'), dictionary)
   return dictionary
 
 
@@ -191,7 +191,7 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
   dependencies = deps_file['deps'].copy()
   os_specific_dependencies = deps_file.get('deps_os', dict())
   if 'all' in command_line_os_requests:
-    for value in os_specific_dependencies.itervalues():
+    for value in os_specific_dependencies.values():
       dependencies.update(value)
   else:
     for os_name in command_line_os_requests:
@@ -204,9 +204,9 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
         raise Exception('%r is parent of %r' % (other_dir, directory))
   list_of_arg_lists = []
   for directory in sorted(dependencies):
-    if not isinstance(dependencies[directory], basestring):
+    if not isinstance(dependencies[directory], str):
       if verbose:
-        print 'Skipping "%s".' % directory
+        print('Skipping "%s".' % directory)
       continue
     if '@' in dependencies[directory]:
       repo, checkoutable = dependencies[directory].split('@', 1)


### PR DESCRIPTION
This PR makes the Skia python build scripts we use in rust-skia compatible with Python3. 

For future rust-skia releases, I'd like to pull Skia directly from this repository and rebase this PR on all future Skia updates together with the [changes that are needed for supporting the skparagraph module](https://github.com/rust-skia/rust-skia/blob/master/skia-bindings/skparagraph.patch).
